### PR TITLE
Better formatting for smaller screens

### DIFF
--- a/octoprint_dashboard/static/css/dashboard.css
+++ b/octoprint_dashboard/static/css/dashboard.css
@@ -85,3 +85,21 @@ svg text {
   width: 100%;
   height: 100%;
 }
+
+@media (max-width: 700px) {
+  #touch .dashboardGridItem {
+      text-align: center;
+      margin-bottom: 20px;
+      padding-bottom: 10px;
+      border-bottom: solid 1px grey!important;
+  }
+  #touch .dashboardGridItem>span::before {
+      content: "\A";
+      white-space: pre;
+  }
+  #touch .dashboardGridItem>div.inline {
+      display: block;
+      margin-top: 10px;
+      text-align: center;
+  }
+}


### PR DESCRIPTION
Improved dashboard formatting when using touch UI plugin on a small screen. 

From this: 
![image](https://user-images.githubusercontent.com/35882868/65234275-9b6f3c80-db17-11e9-86d0-1054b89e8c79.png)

To this:
![image](https://user-images.githubusercontent.com/35882868/65234320-b346c080-db17-11e9-979b-eb888ac73fae.png)

Only applies when touch UI is active and on screens with a width less than 700px