### PR TITLE
fix filename with non-ascii chars not displayed correctly

### DIFF
--- a/octoprint_dashboard/templates/dashboard_tab.jinja2
+++ b/octoprint_dashboard/templates/dashboard_tab.jinja2
@@ -193,7 +193,7 @@
     <!-- File name -->
     <div class="dashboardGridItem" data-bind="visible: printerStateModel.isPrinting()">
       <img class="dashboardIcon" src="plugin/dashboard/static/img/file-icon.png">
-      <span id="fileInfo" data-bind="attr: { title: 'File' }, html: printerStateModel.filename()"></span>
+      <span id="fileInfo" data-bind="attr: { title: 'File' }, html: printerStateModel.filedisplay()"></span>
     </div>
 
     <div class="dasboardGridContainer">


### PR DESCRIPTION
Dashboard did not render file names containing non-ascii characters like öäü correctly. Use printerStateModels filedisplay() instead of filename() to fix that.