### PR TITLE
Fixed camera order & added camera names as their tooltips

### DIFF
--- a/octoprint_dashboard/templates/dashboard_tab.jinja2
+++ b/octoprint_dashboard/templates/dashboard_tab.jinja2
@@ -255,8 +255,8 @@
   <div id="dashboard_webcam_container" data-bind="visible: settingsViewModel.settings.plugins.dashboard.showWebCam()">
     <div id="webcam_toggle" data-bind="visible: webcamState() != 0">
       <div data-bind="visible: MulticamAvailable()">
-        <div data-bind="foreach: multicam_profiles">
-          <input class="cameraStreamIcon" id="cameraButtonIcon" title="Switch camera stream" type="image" src="plugin/dashboard/static/img/webcam-icon.png" data-bind="click: function(){$parent.webcamState( $index()+1 );}" />
+        <div data-bind="foreach: multicam_profiles.slice(0).reverse()">
+          <input class="cameraStreamIcon" id="cameraButtonIcon" type="image" src="plugin/dashboard/static/img/webcam-icon.png" data-bind="attr: { title: name }, click: function(){$parent.webcamState( $index()+1 );}" />
         </div>        
       </div>
 


### PR DESCRIPTION
- The cameras were shown in the opposite order to how they are shown in the settings. The order is now shown correctly on screen.

- Changes the camera icons tooltips to show the camera’s name as shown under Multicam plugin’s properties.

