### PR TITLE
Fixed camera name not matching camera URL issue

### DIFF
--- a/octoprint_dashboard/static/js/dashboard.js
+++ b/octoprint_dashboard/static/js/dashboard.js
@@ -481,7 +481,7 @@ $(function () {
         
         self.onBeforeBinding = function() {
             if(self.MulticamAvailable()) {
-                self.multicam_profiles(self.settingsViewModel.settings.plugins.multicam.multicam_profiles());
+                self.multicam_profiles(self.settingsViewModel.settings.plugins.multicam.multicam_profiles().reverse());
             }
         };
 
@@ -504,7 +504,7 @@ $(function () {
             if (self.webcamState() > 0 && self.settingsViewModel.settings.webcam && self.settingsViewModel.settings.plugins.dashboard.showWebCam() == true) {
                 if(self.MulticamAvailable()) {
                     var urlPosition = self.webcamState() - 1;
-                    return self.settingsViewModel.settings.plugins.multicam.multicam_profiles()[urlPosition].URL() + '?' + new Date().getTime();
+                    return self.multicam_profiles()[urlPosition].URL() + '?' + new Date().getTime();
                 } else {
                     return self.settingsViewModel.settings.webcam.streamUrl() + '?' + new Date().getTime();
                 }

--- a/octoprint_dashboard/templates/dashboard_tab.jinja2
+++ b/octoprint_dashboard/templates/dashboard_tab.jinja2
@@ -255,7 +255,7 @@
   <div id="dashboard_webcam_container" data-bind="visible: settingsViewModel.settings.plugins.dashboard.showWebCam()">
     <div id="webcam_toggle" data-bind="visible: webcamState() != 0">
       <div data-bind="visible: MulticamAvailable()">
-        <div data-bind="foreach: multicam_profiles.slice(0).reverse()">
+        <div data-bind="foreach: multicam_profiles()">
           <input class="cameraStreamIcon" id="cameraButtonIcon" type="image" src="plugin/dashboard/static/img/webcam-icon.png" data-bind="attr: { title: name }, click: function(){$parent.webcamState( $index()+1 );}" />
         </div>        
       </div>


### PR DESCRIPTION
Since reversing the camera buttons in the jinja2, this order was then not matched in the JS. To fix this I have moved the reversing of the array into the JS and made the JS always use this reordered array.